### PR TITLE
chore: Update CORS for quantumescape.netlify.app

### DIFF
--- a/netlify/functions/utils/cors.js
+++ b/netlify/functions/utils/cors.js
@@ -16,9 +16,8 @@ const getAllowedOrigins = () => {
     'http://localhost:8888',
     'https://qplay.netlify.app',
     'https://quantum-escape.netlify.app',
-    'https://quantumquest.netlify.app',
-    'https://dev-quantumquest.netlify.app',
-    'https://dev--quantumquest.netlify.app'  // Netlify branch deploy format
+    'https://quantumescape.netlify.app',
+    'https://dev--quantumescape.netlify.app'  // Netlify branch deploy format
   ];
 
   // Add any site URL from Netlify


### PR DESCRIPTION
Updated domains:
- quantumescape.netlify.app (production)
- dev--quantumescape.netlify.app (dev branch deploy)

## Summary by Sourcery

Enhancements:
- Replace legacy quantumquest Netlify origins with quantumescape production and branch deploy origins in the CORS allowlist.